### PR TITLE
Lambda removals

### DIFF
--- a/pyfilter/algorithms/base.py
+++ b/pyfilter/algorithms/base.py
@@ -97,6 +97,8 @@ class SequentialAlgorithm(BaseAlgorithm):
         for yt in self._iterator:
             self.update(yt)
 
+        self._iterator = None
+
         return self
 
 

--- a/pyfilter/algorithms/kernels.py
+++ b/pyfilter/algorithms/kernels.py
@@ -210,8 +210,7 @@ def _shrink(values, w, ess):
     :rtype: torch.Tensor, torch.Tensor
     """
     # ===== Calculate mean ===== #
-    if values.dim() > w.dim():
-        w = w.unsqueeze(-1)
+    w = add_dimensions(w, values.dim())
 
     mean = (w * values).sum(0)
 
@@ -274,7 +273,7 @@ class AdaptiveShrinkageKernel(BaseKernel):
 
         # ===== Mutate parameters ===== #
         for p, (m, s), delta in zip(parameters, meanscales, self.get_diff()):
-            switched = delta.abs() < self._eps
+            switched = (delta.abs() < self._eps).all()
 
             p.t_values = _jitter(
                 m if not switched else p.t_values,

--- a/pyfilter/algorithms/kernels.py
+++ b/pyfilter/algorithms/kernels.py
@@ -373,7 +373,7 @@ class ParticleMetropolisHastings(BaseKernel):
 
         raise NotImplementedError()
 
-    def update(self, parameters, filter_, weights):
+    def _update(self, parameters, filter_, weights):
         # ===== Construct distribution ===== #
         dist = self.define_pdf(parameters, weights)
 

--- a/pyfilter/algorithms/kernels.py
+++ b/pyfilter/algorithms/kernels.py
@@ -8,7 +8,7 @@ from torch.distributions import MultivariateNormal, Independent
 
 
 class BaseKernel(object):
-    def __init__(self, record_stats=True, length=None):
+    def __init__(self, record_stats=True, length=2):
         """
         The base kernel used for propagating parameters.
         :param record_stats: Whether to record the statistics

--- a/pyfilter/algorithms/ness.py
+++ b/pyfilter/algorithms/ness.py
@@ -49,7 +49,7 @@ class NESS(SequentialAlgorithm):
 
             # Nested filters require parameters to have an extra dimension
             if isinstance(self.filter, ParticleFilter):
-                th.view_(1)
+                th.values = th.values.unsqueeze(1)
 
         # ===== Re-initialize distributions ===== #
         for mod in [self.filter.ssm.hidden, self.filter.ssm.observable]:

--- a/pyfilter/algorithms/nessmc2.py
+++ b/pyfilter/algorithms/nessmc2.py
@@ -44,7 +44,7 @@ class NESSMC2(SequentialAlgorithm):
         for yt in self._iterator:
             self.update(yt)
 
-        self._iterator = None
+        self._iterator = self._smc2._iterator = self._ness._iterator = None
 
         return self
 

--- a/pyfilter/algorithms/nessmc2.py
+++ b/pyfilter/algorithms/nessmc2.py
@@ -28,7 +28,7 @@ class NESSMC2(SequentialAlgorithm):
 
         # ===== Set some key-worded arguments ===== #
         self._smc2 = SMC2(self.filter, particles, resampling=resampling, threshold=smc2_threshold)
-        self._ness = NESS(self._smc2.filter, particles, resampling=resampling, **nesskwargs)
+        self._ness = NESS(self.filter, particles, resampling=resampling, **nesskwargs)
 
     @property
     def logged_ess(self):

--- a/pyfilter/algorithms/nessmc2.py
+++ b/pyfilter/algorithms/nessmc2.py
@@ -44,6 +44,8 @@ class NESSMC2(SequentialAlgorithm):
         for yt in self._iterator:
             self.update(yt)
 
+        self._iterator = None
+
         return self
 
     def update(self, y):

--- a/pyfilter/resampling.py
+++ b/pyfilter/resampling.py
@@ -92,6 +92,9 @@ def residual(w):
 
     numtosample = w.shape[0] - floored.sum(0)
 
+    if numtosample == 0:
+        return repeated
+
     inds[:-numtosample] = repeated
     inds[-numtosample:] = multinomial(torch.zeros(numtosample))
 


### PR DESCRIPTION
The ambition was to remove lambdas in order to enable pickling (for parallel computing), but seems as though that wasn't necessary, except for removing tqdm after finishing calls to `fit`